### PR TITLE
Verify PHP >= 7.0.

### DIFF
--- a/src/Synful/Synful.php
+++ b/src/Synful/Synful.php
@@ -50,6 +50,8 @@ class Synful
      */
     public static function initialize()
     {
+        // Make sure we aren't using that pesky PHP < 7.0
+        0 <=> 0;
 
         // Load console color codes
         Colors::loadColors();


### PR DESCRIPTION
Even though the composer requirements specify PHP >= 7.0, it feels somewhat unappreciative of new features to not make use of the spaceship operator in some way. Since a savvy developer could fork the repo and change the requirements to an older version of PHP, we will make it a little harder with this PHP7 validator.