### PR TITLE
Moved global function autoloading to main file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,7 @@
     "autoload": {
         "psr-4": {
             "Synful\\": "src/Synful"
-        },
-        "files": [
-            "src/Synful/Util/Functions/Encryption.php",
-            "src/Synful/Util/Functions/Logging.php",
-            "src/Synful/Util/Functions/Strings.php",
-            "src/Synful/Util/Functions/System.php",
-            "src/Synful/Util/Functions/Sql.php"
-        ]
+        }
     },
     "require": {
         "php": ">=7.0",

--- a/src/Synful/DataManagement/Models/APIKey.php
+++ b/src/Synful/DataManagement/Models/APIKey.php
@@ -375,10 +375,7 @@ class APIKey
             if ($print_key) {
                 sf_info(
                     'New Private '.(($is_master) ? 'Master' : '').
-                    ' API Key: '.$new_key['key'],
-                    true,
-                    false,
-                    false
+                    ' API Key: '.$new_key['key']
                 );
             }
 

--- a/src/Synful/Synful.php
+++ b/src/Synful/Synful.php
@@ -66,6 +66,9 @@ class Synful
         // Make sure we aren't using that pesky PHP < 7.0
         0 <=> 0;
 
+        // Load Global Functions
+        self::loadGlobalFunctions();
+
         // Load console color codes
         Colors::loadColors();
 
@@ -237,6 +240,18 @@ class Synful
                 'Note: Request handlers are case sensitive. '.
                 'We recommend using TitleCase for request handler names.'
             );
+        }
+    }
+
+    /**
+     * Automatically include all function libraries stored in Global Functions.
+     */
+    private static function loadGlobalFunctions()
+    {
+        foreach (scandir('./src/Synful/Util/Functions') as $func_lib) {
+            if (substr($func_lib, 0, 1) !== '.') {
+                include_once './src/Synful/Util/Functions/'.$func_lib;
+            }
         }
     }
 


### PR DESCRIPTION
* Automated the process of global function autoloading so that a definition for each function library doesn't have to be made
* Fixed master API key being printed out on first time run. (Key will be printed to server logs now).