### PR TITLE
#75 better endpoints

### DIFF
--- a/src/Synful/RequestHandlers/AdvancedEndpointsExample.php
+++ b/src/Synful/RequestHandlers/AdvancedEndpointsExample.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Synful\RequestHandlers;
+
+use Synful\Util\Framework\Request;
+use Synful\Util\Framework\RequestHandler;
+
+/**
+ * New Request Handler Class.
+ */
+class AdvancedEndpointsExample implements RequestHandler
+{
+    /**
+     * Override the handler endpoint
+     * Example: http://myapi.net/user/search
+     * uses the endpoint `user/search`.
+     *
+     * You can also add fields to the endpoint,
+     * In this example, we add the `id` field.
+     *
+     * You can access these fields using
+     * `$request->field('id')`.
+     *
+     * @var string
+     */
+    public $endpoint = 'example/endpoint/{id}';
+
+    /**
+     * Function for handling request and returning a response.
+     *
+     * @param Request $request
+     * @return \Synful\Util\Framework\Response|array
+     */
+    public function handleRequest(Request $request)
+    {
+        return [
+            'message' => 'You selected ID: '.$request->field('id'),
+        ];
+    }
+}

--- a/src/Synful/RequestHandlers/InputExample.php
+++ b/src/Synful/RequestHandlers/InputExample.php
@@ -34,7 +34,7 @@ class InputExample implements RequestHandler
             return sf_response(
                 500,
                 [
-                    'error' => 'Missing name parameter.'
+                    'error' => 'Missing name parameter.',
                 ]
             );
         } else {

--- a/src/Synful/RequestHandlers/InputExample.php
+++ b/src/Synful/RequestHandlers/InputExample.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Synful\RequestHandlers;
+
+use Synful\Util\Framework\Request;
+use Synful\Util\Framework\RequestHandler;
+
+/**
+ * New Request Handler Class.
+ */
+class InputExample implements RequestHandler
+{
+    /**
+     * Override the handler endpoint
+     * Example: http://myapi.net/user/search
+     * uses the endpoint `user/search`.
+     *
+     * @var string
+     */
+    public $endpoint = 'example/input';
+
+    /**
+     * Function for handling request and returning a response.
+     *
+     * @param Request $request
+     * @return \Synful\Util\Framework\Response|array
+     */
+    public function handleRequest(Request $request)
+    {
+        // Read input from the data passed in the request.
+        $name = $request->input('name');
+
+        if ($name == null) {
+            return sf_response(
+                500,
+                [
+                    'error' => 'Missing name parameter.'
+                ]
+            );
+        } else {
+            return [
+                'your_name_is' => $name,
+            ];
+        }
+    }
+}

--- a/src/Synful/RequestHandlers/SqlExample.php
+++ b/src/Synful/RequestHandlers/SqlExample.php
@@ -19,7 +19,7 @@ class SqlExample implements RequestHandler
      *
      * @var string
      */
-    public $endpoint = 'example/sql';
+    public $endpoint = 'example/sql/{id}';
 
     /**
      * Implement the APIKeyValidation middleware
@@ -40,13 +40,12 @@ class SqlExample implements RequestHandler
      */
     public function handleRequest(Request $request)
     {
-
         // Define SQL Databases and Servers in 'SqlServers.php'
         // Create a reference to the SQL Database Connection
         $sql_con = sf_db('server_name.db_name');
 
         // Validate the request
-        if (! isset($request['id']) || ! is_int($request['id'])) {
+        if ($request->field('id') == null || ! is_int($request->field('id'))) {
             return sf_response(
                 400,
                 [
@@ -55,12 +54,21 @@ class SqlExample implements RequestHandler
             );
         } else {
             // Do not use $sql_con->openSql();
-            // The connection has already been opened by Synful and will be closed as needed.
+            // The connection has already been opened by Synful
+            // and will be closed as needed.
 
             // Query MySql for the user row
-            // Parameters: Query string, array containing type definitions and parameter binds,
-            // bool set to true to return a result set
-            $result = $sql_con->executeSql('SELECT * FROM `mytable` WHERE `id`=?', ['i', $request['id']], true);
+            // Parameters: Query string, array containing type
+            // definitions and parameter binds, bool set to true
+            // to return a result set
+            $result = $sql_con->executeSql(
+                'SELECT * FROM `mytable` WHERE `id`=?',
+                [
+                    'i',
+                    $request->field('id'),
+                ],
+                true
+            );
 
             // Convert the data from SQL to an array
             $db_row = mysqli_fetch_assoc($result);
@@ -69,7 +77,8 @@ class SqlExample implements RequestHandler
             return $db_row;
 
             // Do not use $sql_con->closeSql();
-            // The connection will be closed as needed by Synful automatically
+            // The connection will be closed as
+            // needed by Synful automatically.
         }
     }
 }

--- a/src/Synful/Synful.php
+++ b/src/Synful/Synful.php
@@ -134,20 +134,23 @@ class Synful
      *
      * @param  string                          $handler
      * @param  string                          $request
+     * @param  array                           $fields
      * @param  string                          $ip
      * @return \Synful\Util\Framework\Response
      */
     public static function handleRequest(
         string $handler,
         string $request,
+        array  $fields,
         string $ip
     ) {
-        $data = (array) json_decode($request);
+        $data = (array) json_decode($request, true);
 
         $request = new Request([
             'ip' => $ip,
             'headers' => apache_request_headers(),
             'data' => $data,
+            'fields' => $fields,
         ]);
 
         try {

--- a/src/Synful/Util/Framework/Object.php
+++ b/src/Synful/Util/Framework/Object.php
@@ -2,8 +2,6 @@
 
 namespace Synful\Util\Framework;
 
-use Exception;
-
 /**
  * Trait used as a base for classes with constructors that match their properties.
  */
@@ -20,7 +18,11 @@ trait Object
             if (property_exists($this, $key)) {
                 $this->{$key} = $value;
             } else {
-                throw new Exception('Unknown property \''.$key.'\' in Object definition.');
+                throw new SynfulException(
+                    500,
+                    -1,
+                    'Unknown property \''.$key.'\' in Object definition.'
+                );
             }
         }
     }
@@ -42,7 +44,11 @@ trait Object
                 $this->{$name} = $arguments[0];
             }
         } else {
-            throw new Exception('Call to undefined function \''.$name.'\'.');
+            throw new SynfulException(
+                500,
+                -2,
+                'Call to undefined function \''.$name.'\'.'
+            );
         }
 
         return $ret;

--- a/src/Synful/Util/Framework/Request.php
+++ b/src/Synful/Util/Framework/Request.php
@@ -85,7 +85,7 @@ class Request
 
         foreach ($keys as $key) {
             if (! array_key_exists($key, $result)) {
-                return null;
+                return;
             }
 
             $result = $result[$key];
@@ -102,7 +102,7 @@ class Request
         }
 
         if (! array_key_exists($final_key, $result)) {
-            return null;
+            return;
         }
 
         return $result[$final_key];

--- a/src/Synful/Util/Framework/SynfulException.php
+++ b/src/Synful/Util/Framework/SynfulException.php
@@ -47,6 +47,8 @@ class SynfulException extends Exception
         1015 => 'Unable to connect to MySql server. Check \'SqlServers.php\'.',
         1016 => 'Invalid response type returned from Request Handler.',
         1017 => 'Invalid middleware definition.',
+        1018 => 'Invalid field count in request path.',
+        1019 => 'Invalid path element.',
     ];
 
     /**

--- a/src/Synful/Util/Functions/System.php
+++ b/src/Synful/Util/Functions/System.php
@@ -59,6 +59,10 @@ if (! function_exists('sf_response')) {
      */
     function sf_response(int $code = 200, $response = null)
     {
+        if ($response != null && ! is_array($response)) {
+            throw new \Synful\Util\Framework\SynfulException(500, 1016);
+        }
+
         return new \Synful\Util\Framework\Response([
             'code' => $code,
             'response' => $response,

--- a/src/Synful/Util/WebListener/WebListener.php
+++ b/src/Synful/Util/WebListener/WebListener.php
@@ -34,7 +34,7 @@ class WebListener
                 $handler_endpoint_elements = explode('/', $handler->endpoint);
                 $handler_endpoint_path = [];
                 $handler_endpoint_properties = [];
-                for ($i=0;$i<count($handler_endpoint_elements);$i++) {
+                for ($i = 0; $i < count($handler_endpoint_elements); $i++) {
                     $field = $handler_endpoint_elements[$i];
 
                     if (
@@ -79,8 +79,9 @@ class WebListener
                         exit;
                     }
 
-                    foreach ($handler_endpoint_properties as $key => $property)
-                    {
+                    foreach (
+                        $handler_endpoint_properties as $key => $property
+                    ) {
                         $fields[$property] = $endpoint_elements[$key];
                     }
 

--- a/templates/RequestHandler.tmpl
+++ b/templates/RequestHandler.tmpl
@@ -15,6 +15,12 @@ class RequestHandlerName implements RequestHandler
      * Example: http://myapi.net/user/search
      * uses the endpoint `user/search`.
      *
+     * You can also add fields to the endpoint
+     * by encapsulating them with `{field_name}`.
+     *
+     * You can access these fields using
+     * `$request->field('field_name')`.
+     *
      * @var string
      */
     public $endpoint = 'EndPoint';


### PR DESCRIPTION
* Added request handler fields
* Removed ArrayAccess from Requests and replaced it with the 'input' function
* Made SqlExample.php use fields instead of input
* Updated json_decode to force associative array output
* Updated Object.php trait to use SynfulException
* Added inputs() and fields() functions to Request
* Enforced array response body when using sf_response
* Updated RequestHandler.tmpl for new endpoint implementation